### PR TITLE
Removed backslash which caused a syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports.verify = function()
 			if(!result || !result.authenticated)
 				next('Failed to authenticate user.');
 			fetchIdentifier(result.claimedIdentifier)
-				.then(function(user) {\
+				.then(function(user) {
 					req.user = user;
 					if(useSession)
 					{


### PR DESCRIPTION
I attempted to use a module and it threw a syntax error, caused by a stray backslash. This fixes that.
